### PR TITLE
Add coupling candidate inference agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,11 @@ IFGプロジェクトでは、以下のスクリプト群を互いに独立し�
 - **出力ファイル**：`result/logic_physical_map.json`
 - **エージェント的役割**：論理状態–物理配置マッピングエージェント
 - **依存ライブラリ**：`json`
+
+## infer_coupling_candidates.py
+
+- **機能概要**：論理状態の物理座標をもとに距離を計算し、近接ペアを"coupled"とした一覧JSONを生成する。
+- **入力ファイル/引数**：コマンドライン引数なし。`result/logic_physical_map.json` を読み込む。
+- **出力ファイル**：`result/coupling_candidates.json`
+- **エージェント的役割**：結合候補推定エージェント
+- **依存ライブラリ**：`json`、`math`、`os`

--- a/README.md
+++ b/README.md
@@ -136,3 +136,16 @@ python src/map_state_to_layout.py --states ψ₀ ψ₁ ψ₂ ψ₃ ψ₄ ψ₅ �
 The mapping routine checks that the number of provided state labels matches the
 number of qubits and orders qubits numerically (``Q0``, ``Q1`` ... ``Q15``).
 
+## Coupling Candidate Inference
+
+To determine which logical qubit pairs are likely to be physically coupled, run:
+
+```bash
+python src/infer_coupling_candidates.py
+```
+
+This program reads `result/logic_physical_map.json` and calculates the
+Euclidean distance between all pairs of logical states. The results are saved
+to `result/coupling_candidates.json` and a short summary is printed after
+completion.
+

--- a/src/infer_coupling_candidates.py
+++ b/src/infer_coupling_candidates.py
@@ -67,7 +67,7 @@ def main() -> None:
     mapping = load_mapping(src)
     candidates = infer_couplings(mapping, threshold=1.5)
     write_json(candidates, dst)
-    print(f"Coupling candidates written to {dst}")
+    print(f"Printed {len(candidates)} coupling pair(s) to {dst}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- generate coupling candidate pairs with `infer_coupling_candidates.py`
- document the new agent in `AGENTS.md`
- describe how to run the agent in `README.md`

## Testing
- `python src/infer_coupling_candidates.py`