### PR TITLE
Add semantic weight generator and result

### DIFF
--- a/result/semantic_coupling_map.json
+++ b/result/semantic_coupling_map.json
@@ -1,0 +1,842 @@
+[
+  {
+    "q1": "ψ₀",
+    "q2": "ψ₁",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₀",
+    "q2": "ψ₂",
+    "distance": 2.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₀",
+    "q2": "ψ₃",
+    "distance": 3.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₀",
+    "q2": "ψ₄",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₀",
+    "q2": "ψ₅",
+    "distance": 1.414,
+    "coupled": true,
+    "semantic_weight": 0.3717
+  },
+  {
+    "q1": "ψ₀",
+    "q2": "ψ₆",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₀",
+    "q2": "ψ₇",
+    "distance": 3.162,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₀",
+    "q2": "ψ₈",
+    "distance": 2.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₀",
+    "q2": "ψ₉",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₀",
+    "q2": "ψ₁₀",
+    "distance": 2.828,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₀",
+    "q2": "ψ₁₁",
+    "distance": 3.606,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₀",
+    "q2": "ψ₁₂",
+    "distance": 3.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₀",
+    "q2": "ψ₁₃",
+    "distance": 3.162,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₀",
+    "q2": "ψ₁₄",
+    "distance": 3.606,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₀",
+    "q2": "ψ₁₅",
+    "distance": 4.243,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₁",
+    "q2": "ψ₂",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₁",
+    "q2": "ψ₃",
+    "distance": 2.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₁",
+    "q2": "ψ₄",
+    "distance": 1.414,
+    "coupled": true,
+    "semantic_weight": 0.3717
+  },
+  {
+    "q1": "ψ₁",
+    "q2": "ψ₅",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₁",
+    "q2": "ψ₆",
+    "distance": 1.414,
+    "coupled": true,
+    "semantic_weight": 0.3717
+  },
+  {
+    "q1": "ψ₁",
+    "q2": "ψ₇",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₁",
+    "q2": "ψ₈",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₁",
+    "q2": "ψ₉",
+    "distance": 2.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₁",
+    "q2": "ψ₁₀",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₁",
+    "q2": "ψ₁₁",
+    "distance": 2.828,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₁",
+    "q2": "ψ₁₂",
+    "distance": 3.162,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₁",
+    "q2": "ψ₁₃",
+    "distance": 3.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₁",
+    "q2": "ψ₁₄",
+    "distance": 3.162,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₁",
+    "q2": "ψ₁₅",
+    "distance": 3.606,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₂",
+    "q2": "ψ₃",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₂",
+    "q2": "ψ₄",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₂",
+    "q2": "ψ₅",
+    "distance": 1.414,
+    "coupled": true,
+    "semantic_weight": 0.3717
+  },
+  {
+    "q1": "ψ₂",
+    "q2": "ψ₆",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₂",
+    "q2": "ψ₇",
+    "distance": 1.414,
+    "coupled": true,
+    "semantic_weight": 0.3717
+  },
+  {
+    "q1": "ψ₂",
+    "q2": "ψ₈",
+    "distance": 2.828,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₂",
+    "q2": "ψ₉",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₂",
+    "q2": "ψ₁₀",
+    "distance": 2.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₂",
+    "q2": "ψ₁₁",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₂",
+    "q2": "ψ₁₂",
+    "distance": 3.606,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₂",
+    "q2": "ψ₁₃",
+    "distance": 3.162,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₂",
+    "q2": "ψ₁₄",
+    "distance": 3.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₂",
+    "q2": "ψ₁₅",
+    "distance": 3.162,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₃",
+    "q2": "ψ₄",
+    "distance": 3.162,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₃",
+    "q2": "ψ₅",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₃",
+    "q2": "ψ₆",
+    "distance": 1.414,
+    "coupled": true,
+    "semantic_weight": 0.3717
+  },
+  {
+    "q1": "ψ₃",
+    "q2": "ψ₇",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₃",
+    "q2": "ψ₈",
+    "distance": 3.606,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₃",
+    "q2": "ψ₉",
+    "distance": 2.828,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₃",
+    "q2": "ψ₁₀",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₃",
+    "q2": "ψ₁₁",
+    "distance": 2.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₃",
+    "q2": "ψ₁₂",
+    "distance": 4.243,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₃",
+    "q2": "ψ₁₃",
+    "distance": 3.606,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₃",
+    "q2": "ψ₁₄",
+    "distance": 3.162,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₃",
+    "q2": "ψ₁₅",
+    "distance": 3.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₄",
+    "q2": "ψ₅",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₄",
+    "q2": "ψ₆",
+    "distance": 2.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₄",
+    "q2": "ψ₇",
+    "distance": 3.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₄",
+    "q2": "ψ₈",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₄",
+    "q2": "ψ₉",
+    "distance": 1.414,
+    "coupled": true,
+    "semantic_weight": 0.3717
+  },
+  {
+    "q1": "ψ₄",
+    "q2": "ψ₁₀",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₄",
+    "q2": "ψ₁₁",
+    "distance": 3.162,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₄",
+    "q2": "ψ₁₂",
+    "distance": 2.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₄",
+    "q2": "ψ₁₃",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₄",
+    "q2": "ψ₁₄",
+    "distance": 2.828,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₄",
+    "q2": "ψ₁₅",
+    "distance": 3.606,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₅",
+    "q2": "ψ₆",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₅",
+    "q2": "ψ₇",
+    "distance": 2.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₅",
+    "q2": "ψ₈",
+    "distance": 1.414,
+    "coupled": true,
+    "semantic_weight": 0.3717
+  },
+  {
+    "q1": "ψ₅",
+    "q2": "ψ₉",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₅",
+    "q2": "ψ₁₀",
+    "distance": 1.414,
+    "coupled": true,
+    "semantic_weight": 0.3717
+  },
+  {
+    "q1": "ψ₅",
+    "q2": "ψ₁₁",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₅",
+    "q2": "ψ₁₂",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₅",
+    "q2": "ψ₁₃",
+    "distance": 2.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₅",
+    "q2": "ψ₁₄",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₅",
+    "q2": "ψ₁₅",
+    "distance": 2.828,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₆",
+    "q2": "ψ₇",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₆",
+    "q2": "ψ₈",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₆",
+    "q2": "ψ₉",
+    "distance": 1.414,
+    "coupled": true,
+    "semantic_weight": 0.3717
+  },
+  {
+    "q1": "ψ₆",
+    "q2": "ψ₁₀",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₆",
+    "q2": "ψ₁₁",
+    "distance": 1.414,
+    "coupled": true,
+    "semantic_weight": 0.3717
+  },
+  {
+    "q1": "ψ₆",
+    "q2": "ψ₁₂",
+    "distance": 2.828,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₆",
+    "q2": "ψ₁₃",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₆",
+    "q2": "ψ₁₄",
+    "distance": 2.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₆",
+    "q2": "ψ₁₅",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₇",
+    "q2": "ψ₈",
+    "distance": 3.162,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₇",
+    "q2": "ψ₉",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₇",
+    "q2": "ψ₁₀",
+    "distance": 1.414,
+    "coupled": true,
+    "semantic_weight": 0.3717
+  },
+  {
+    "q1": "ψ₇",
+    "q2": "ψ₁₁",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₇",
+    "q2": "ψ₁₂",
+    "distance": 3.606,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₇",
+    "q2": "ψ₁₃",
+    "distance": 2.828,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₇",
+    "q2": "ψ₁₄",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₇",
+    "q2": "ψ₁₅",
+    "distance": 2.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₈",
+    "q2": "ψ₉",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₈",
+    "q2": "ψ₁₀",
+    "distance": 2.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₈",
+    "q2": "ψ₁₁",
+    "distance": 3.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₈",
+    "q2": "ψ₁₂",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₈",
+    "q2": "ψ₁₃",
+    "distance": 1.414,
+    "coupled": true,
+    "semantic_weight": 0.3717
+  },
+  {
+    "q1": "ψ₈",
+    "q2": "ψ₁₄",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₈",
+    "q2": "ψ₁₅",
+    "distance": 3.162,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₉",
+    "q2": "ψ₁₀",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₉",
+    "q2": "ψ₁₁",
+    "distance": 2.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₉",
+    "q2": "ψ₁₂",
+    "distance": 1.414,
+    "coupled": true,
+    "semantic_weight": 0.3717
+  },
+  {
+    "q1": "ψ₉",
+    "q2": "ψ₁₃",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₉",
+    "q2": "ψ₁₄",
+    "distance": 1.414,
+    "coupled": true,
+    "semantic_weight": 0.3717
+  },
+  {
+    "q1": "ψ₉",
+    "q2": "ψ₁₅",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₁₀",
+    "q2": "ψ₁₁",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₁₀",
+    "q2": "ψ₁₂",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₁₀",
+    "q2": "ψ₁₃",
+    "distance": 1.414,
+    "coupled": true,
+    "semantic_weight": 0.3717
+  },
+  {
+    "q1": "ψ₁₀",
+    "q2": "ψ₁₄",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₁₀",
+    "q2": "ψ₁₅",
+    "distance": 1.414,
+    "coupled": true,
+    "semantic_weight": 0.3717
+  },
+  {
+    "q1": "ψ₁₁",
+    "q2": "ψ₁₂",
+    "distance": 3.162,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₁₁",
+    "q2": "ψ₁₃",
+    "distance": 2.236,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₁₁",
+    "q2": "ψ₁₄",
+    "distance": 1.414,
+    "coupled": true,
+    "semantic_weight": 0.3717
+  },
+  {
+    "q1": "ψ₁₁",
+    "q2": "ψ₁₅",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₁₂",
+    "q2": "ψ₁₃",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₁₂",
+    "q2": "ψ₁₄",
+    "distance": 2.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₁₂",
+    "q2": "ψ₁₅",
+    "distance": 3.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₁₃",
+    "q2": "ψ₁₄",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  },
+  {
+    "q1": "ψ₁₃",
+    "q2": "ψ₁₅",
+    "distance": 2.0,
+    "coupled": false,
+    "semantic_weight": 0.0
+  },
+  {
+    "q1": "ψ₁₄",
+    "q2": "ψ₁₅",
+    "distance": 1.0,
+    "coupled": true,
+    "semantic_weight": 0.4966
+  }
+]

--- a/src/gen_semantic_weights.py
+++ b/src/gen_semantic_weights.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Generate semantic-weighted coupling map from physical proximity."""
+
+import json
+import math
+from typing import List, Dict
+
+INPUT_PATH = "result/coupling_candidates.json"
+OUTPUT_PATH = "result/semantic_coupling_map.json"
+
+
+def load_pairs(path: str) -> List[Dict]:
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def apply_semantic_weights(data: List[Dict]) -> List[Dict]:
+    updated = []
+    for entry in data:
+        d = entry.get("distance", 999)
+        coupled = entry.get("coupled", False)
+        weight = round(math.exp(-0.7 * d), 4) if coupled else 0.0
+        entry["semantic_weight"] = weight
+        updated.append(entry)
+    return updated
+
+
+def save_output(data: List[Dict], path: str) -> None:
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+
+
+def main() -> None:
+    pairs = load_pairs(INPUT_PATH)
+    weighted = apply_semantic_weights(pairs)
+    save_output(weighted, OUTPUT_PATH)
+    print(f"Wrote semantic coupling map to {OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `gen_semantic_weights.py` to compute semantic coupling weights
- generate `result/semantic_coupling_map.json` from existing coupling data

## Testing
- `python src/gen_semantic_weights.py`
