### PR TITLE
Add CLI-based flux pump optimizer

### DIFF
--- a/tools/fluxpump_optimize.py
+++ b/tools/fluxpump_optimize.py
@@ -1,9 +1,9 @@
 """
 Script Name: fluxpump_optimize.py
 Purpose: Optimize flux pump control parameters
-Dependencies: numpy, scipy
+Dependencies: numpy, scipy, argparse (optionally matplotlib)
 Usage:
-    python tools/fluxpump_optimize.py
+    python tools/fluxpump_optimize.py [--freq_p GHz] [--eps val] [--bias val]
 
 Outputs:
     - 最適パラメータ
@@ -13,6 +13,7 @@ Outputs:
 Author: Codex（MetaShirou prompt経由）
 """
 
+import argparse
 import numpy as np
 from scipy.optimize import minimize
 
@@ -48,12 +49,50 @@ def objective(x: np.ndarray) -> float:
 
 
 if __name__ == "__main__":
-    x0 = np.array([2 * np.pi * 7.5e9, 0.1, 0.9])
-    res = minimize(objective, x0, method="BFGS")
+    parser = argparse.ArgumentParser(description="Optimize flux pump parameters")
+    parser.add_argument("--freq_p", type=float, default=7.5, help="pump frequency in GHz")
+    parser.add_argument("--eps", type=float, default=0.1, help="pump amplitude")
+    parser.add_argument("--bias", type=float, default=0.9, help="bias current")
+    parser.add_argument("--csv", type=str, default="", help="optional CSV output path")
+    parser.add_argument("--plot", type=str, default="", help="optional plot output path")
+    args = parser.parse_args()
+
+    x0 = np.array([2 * np.pi * args.freq_p * 1e9, args.eps, args.bias])
+    bounds = [
+        (2 * np.pi * 6e9, 2 * np.pi * 9e9),
+        (0.01, 1.0),
+        (0.5, 1.2),
+    ]
+
+    res = minimize(objective, x0, bounds=bounds, method="L-BFGS-B")
     w_opt, ep_opt, ib_opt = res.x
-    print("Optimal ω_p:", w_opt)
-    print("Optimal ε_p:", ep_opt)
-    print("Optimal I_bias:", ib_opt)
-    print("g_LS:", g_ls(w_opt, ep_opt, ib_opt))
-    print("BW:", bandwidth())
+    g_val = g_ls(w_opt, ep_opt, ib_opt)
+
+    print(f"ω_p [GHz]: {w_opt / (2 * np.pi * 1e9):.6f}")
+    print("ε_p:", ep_opt)
+    print("I_bias:", ib_opt)
+    print("g_LS:", g_val)
     print("Minimum J:", res.fun)
+
+    if args.csv:
+        import csv
+
+        with open(args.csv, "w", newline="") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(["omega_p_GHz", "epsilon_p", "i_bias", "g_LS", "J"])
+            writer.writerow([w_opt / (2 * np.pi * 1e9), ep_opt, ib_opt, g_val, res.fun])
+
+    if args.plot:
+        try:
+            import matplotlib.pyplot as plt
+
+            plt.figure()
+            plt.scatter(w_opt / (2 * np.pi * 1e9), g_val, color="red")
+            plt.xlabel("ω_p [GHz]")
+            plt.ylabel("g_LS")
+            plt.title("Flux Pump Optimization Result")
+            plt.grid(True)
+            plt.tight_layout()
+            plt.savefig(args.plot)
+        except Exception as exc:
+            print("Plot failed:", exc)


### PR DESCRIPTION
## Summary
- extend `tools/fluxpump_optimize.py` with command line interface
- implement bounds and L-BFGS-B optimization
- optional CSV/plot outputs

## Testing
- `python tools/fluxpump_optimize.py --freq_p 7.5 --eps 0.1 --bias 0.9` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683ae99e9ab883239022e193239c6e72