### PR TITLE
Add measurement scripts for quantum data analysis

### DIFF
--- a/src/compute_noise_spectrum.py
+++ b/src/compute_noise_spectrum.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Compute noise spectrum and fit 1/f + white noise model."""
+import csv
+import json
+import warnings
+from typing import Tuple
+
+import numpy as np
+from scipy.optimize import curve_fit
+
+
+def load_csv(path: str) -> Tuple[np.ndarray, np.ndarray]:
+    data = np.genfromtxt(path, delimiter=",", names=True)
+    freq = data[data.dtype.names[0]]
+    psd = data[data.dtype.names[1]]
+    return np.asarray(freq), np.asarray(psd)
+
+
+def noise_model(w: np.ndarray, A: float, B: float) -> np.ndarray:
+    return A / np.maximum(w, 1e-12) + B
+
+
+def fit_noise(freq: np.ndarray, psd: np.ndarray) -> Tuple[float, float, float]:
+    popt, _ = curve_fit(noise_model, freq, psd, p0=[1e-12, 1e-12], maxfev=10000)
+    residual = np.mean((psd - noise_model(freq, *popt)) ** 2)
+    return popt[0], popt[1], residual
+
+
+def main(path: str, out_json: str) -> None:
+    freq, psd = load_csv(path)
+    A, B, res = fit_noise(freq, psd)
+    if res > np.var(psd) * 0.1:
+        warnings.warn("Poor fit quality detected")
+    result = {"noise_model": {"A": A, "B": B}}
+    with open(out_json, "w") as fh:
+        json.dump(result, fh, indent=2)
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) < 3:
+        print("Usage: compute_noise_spectrum.py <input.csv> <output.json>")
+        sys.exit(1)
+    main(sys.argv[1], sys.argv[2])

--- a/src/extract_quantum_metrics.py
+++ b/src/extract_quantum_metrics.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Extract resonance parameters from filtered RF data."""
+import csv
+import json
+import math
+from typing import Tuple, List
+
+import numpy as np
+from scipy.optimize import curve_fit
+
+
+def load_csv(path: str) -> Tuple[np.ndarray, np.ndarray]:
+    with open(path, "r", newline="") as fh:
+        reader = csv.DictReader(fh)
+        freqs = []
+        amps = []
+        for row in reader:
+            f = float(row.get("timestamp", row.get("freq", 0)))
+            if "I" in row and "Q" in row:
+                i = float(row["I"])
+                q = float(row["Q"])
+                amp = math.hypot(i, q)
+            elif "abs" in row:
+                amp = float(row["abs"])
+            else:
+                continue
+            freqs.append(f)
+            amps.append(amp)
+    return np.array(freqs), np.array(amps)
+
+
+def lorentzian(f: np.ndarray, fc: float, ql: float, depth: float, base: float) -> np.ndarray:
+    return base - depth / (1.0 + 4.0 * ql ** 2 * ((f - fc) / fc) ** 2)
+
+
+def fit_lorentzian(freqs: np.ndarray, amps: np.ndarray) -> Tuple[float, float, float, float]:
+    fc_guess = freqs[np.argmin(amps)]
+    q_guess = 1e4
+    depth_guess = max(amps) - min(amps)
+    base_guess = max(amps)
+    popt, _ = curve_fit(lorentzian, freqs, amps, p0=[fc_guess, q_guess, depth_guess, base_guess])
+    return tuple(popt)
+
+
+def estimate_qi_qe(ql: float, amp_min: float, base: float) -> Tuple[float, float]:
+    s_min = amp_min / base if base != 0 else 1.0
+    qe = ql / max(1.0 - s_min, 1e-12)
+    qi = 1.0 / max(1.0 / ql - 1.0 / qe, 1e-12)
+    return qi, qe
+
+
+def main(path: str, out_json: str) -> None:
+    freqs, amps = load_csv(path)
+    if len(freqs) == 0:
+        raise RuntimeError("No data found in CSV")
+    fc, ql, depth, base = fit_lorentzian(freqs, amps)
+    amp_min = lorentzian(fc, fc, ql, depth, base)
+    qi, qe = estimate_qi_qe(ql, amp_min, base)
+    result = {
+        "fc_GHz": fc,
+        "Q_loaded": ql,
+        "Q_internal": qi,
+        "Q_external": qe,
+    }
+    with open(out_json, "w") as fh:
+        json.dump(result, fh, indent=2)
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) < 3:
+        print("Usage: extract_quantum_metrics.py <input.csv> <output.json>")
+        sys.exit(1)
+    main(sys.argv[1], sys.argv[2])

--- a/src/extract_t2_from_dd.py
+++ b/src/extract_t2_from_dd.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Estimate T2 from dynamical decoupling sequence data."""
+import csv
+import json
+from typing import Tuple
+
+import numpy as np
+from scipy.optimize import curve_fit
+import matplotlib.pyplot as plt
+
+
+def load_csv(path: str) -> Tuple[np.ndarray, np.ndarray]:
+    data = np.genfromtxt(path, delimiter=",", names=True)
+    n = data[data.dtype.names[0]]
+    signal = data[data.dtype.names[1]]
+    return np.asarray(n), np.asarray(signal)
+
+
+def decay_model(n: np.ndarray, gamma: float, amp: float) -> np.ndarray:
+    return amp * np.exp(-gamma * n)
+
+
+def fit_decay(n: np.ndarray, signal: np.ndarray) -> Tuple[float, float]:
+    popt, _ = curve_fit(decay_model, n, signal, p0=[1e-9, signal[0]], maxfev=10000)
+    return popt[0], popt[1]
+
+
+def save_plot(n: np.ndarray, signal: np.ndarray, gamma: float, path: str) -> None:
+    plt.figure()
+    plt.plot(n, signal, "o", label="data")
+    plt.plot(n, decay_model(n, gamma, signal[0]), label="fit")
+    plt.xlabel("N")
+    plt.ylabel("Coherence")
+    plt.title("T2 extraction")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(path)
+    plt.close()
+
+
+def main(path: str, out_json: str) -> None:
+    n, sig = load_csv(path)
+    gamma, amp = fit_decay(n, sig)
+    t2 = 1.0 / gamma if gamma != 0 else float("inf")
+    result = {"Gamma_dec": gamma, "T2": t2}
+    with open(out_json, "w") as fh:
+        json.dump(result, fh, indent=2)
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) < 3:
+        print("Usage: extract_t2_from_dd.py <input.csv> <output.json>")
+        sys.exit(1)
+    main(sys.argv[1], sys.argv[2])

--- a/src/sim_cooling_heatload.py
+++ b/src/sim_cooling_heatload.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Simulate radiative heat load between cryostat shields."""
+import json
+import os
+from typing import List
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+SIGMA = 5.670374419e-8  # Stefan-Boltzmann constant
+
+
+class Layer:
+    def __init__(self, area: float, emissivity: float, thot: float, tcold: float):
+        self.area = area
+        self.epsilon = emissivity
+        self.thot = thot
+        self.tcold = tcold
+
+    def heatload(self) -> float:
+        return self.epsilon * SIGMA * self.area * (self.thot ** 4 - self.tcold ** 4)
+
+
+def simulate() -> List[float]:
+    layers = [
+        Layer(area=0.1, emissivity=0.05, thot=300, tcold=50),
+        Layer(area=0.1, emissivity=0.05, thot=50, tcold=4),
+        Layer(area=0.1, emissivity=0.05, thot=4, tcold=0.1),
+    ]
+    return [lay.heatload() for lay in layers]
+
+
+def save_plot(values: List[float], path: str) -> None:
+    make_dir(os.path.dirname(path))
+    plt.figure()
+    plt.bar(range(len(values)), values)
+    plt.xlabel("Layer")
+    plt.ylabel("Heatload [W]")
+    plt.title("Radiative Heatload")
+    plt.tight_layout()
+    plt.savefig(path)
+    plt.close()
+
+
+def make_dir(path: str) -> None:
+    os.makedirs(path, exist_ok=True)
+
+
+def main() -> None:
+    loads = simulate()
+    total = float(np.sum(loads))
+    print("Total heat load:", total)
+    save_plot(loads, "docs/plot/fig6_4.png")
+    with open("result/heatload.json", "w") as fh:
+        json.dump({"layers": loads, "total": total}, fh, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/visualize_results.py
+++ b/src/visualize_results.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Visualize analysis results from extract scripts."""
+import json
+import os
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def make_dir(path: str) -> None:
+    os.makedirs(path, exist_ok=True)
+
+
+def plot_resonance(metrics_json: str, out_dir: str) -> None:
+    with open(metrics_json, "r") as fh:
+        m = json.load(fh)
+    fc = m["fc_GHz"]
+    ql = m["Q_loaded"]
+    f = np.linspace(fc * 0.95, fc * 1.05, 400)
+    lor = 1 - 1 / (1 + 4 * ql ** 2 * ((f - fc) / fc) ** 2)
+    plt.figure()
+    plt.plot(f, lor, label="Lorentzian")
+    plt.xlabel("Frequency [GHz]")
+    plt.ylabel("Amplitude (arb.)")
+    plt.title("Resonance Spectrum")
+    plt.legend()
+    make_dir(out_dir)
+    plt.tight_layout()
+    plt.savefig(os.path.join(out_dir, "fig6_1.png"))
+    plt.close()
+
+
+def plot_noise(noise_json: str, out_dir: str) -> None:
+    with open(noise_json, "r") as fh:
+        data = json.load(fh)
+    A = data["noise_model"]["A"]
+    B = data["noise_model"]["B"]
+    w = np.logspace(1, 6, 400)
+    S = A / w + B
+    plt.figure()
+    plt.loglog(w, S)
+    plt.xlabel("Frequency [Hz]")
+    plt.ylabel("PSD")
+    plt.title("Noise Spectrum")
+    make_dir(out_dir)
+    plt.tight_layout()
+    plt.savefig(os.path.join(out_dir, "fig6_2.png"))
+    plt.close()
+
+
+def plot_t2(dd_json: str, out_dir: str) -> None:
+    with open(dd_json, "r") as fh:
+        data = json.load(fh)
+    gamma = data["Gamma_dec"]
+    N = np.arange(0, 100, 1)
+    coh = np.exp(-gamma * N)
+    plt.figure()
+    plt.plot(N, coh)
+    plt.xlabel("N")
+    plt.ylabel("Coherence")
+    plt.title("T2 Decay")
+    make_dir(out_dir)
+    plt.tight_layout()
+    plt.savefig(os.path.join(out_dir, "fig6_3.png"))
+    plt.close()
+
+
+def main(metrics_json: str, noise_json: str, dd_json: str) -> None:
+    out_dir = "docs/plot"
+    plot_resonance(metrics_json, out_dir)
+    plot_noise(noise_json, out_dir)
+    plot_t2(dd_json, out_dir)
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) < 4:
+        print("Usage: visualize_results.py <metrics.json> <noise.json> <dd.json>")
+        sys.exit(1)
+    main(sys.argv[1], sys.argv[2], sys.argv[3])


### PR DESCRIPTION
## Summary
- implement `extract_quantum_metrics.py` for Lorentzian fits
- add `compute_noise_spectrum.py` for 1/f noise analysis
- create `extract_t2_from_dd.py` to estimate T2 from DD data
- provide `visualize_results.py` that draws figures from JSON outputs
- include `sim_cooling_heatload.py` for cryostat heat load evaluation

## Testing
- `python3 -m py_compile src/compute_noise_spectrum.py src/extract_quantum_metrics.py src/extract_t2_from_dd.py src/sim_cooling_heatload.py src/visualize_results.py`

------
https://chatgpt.com/codex/tasks/task_e_683b0f8f24888323be585ecb8c504e31