### PR TITLE
Improve setup and testing workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 install:
 	pip install -r requirements.txt
+	pip install -e .
 
 dev-install:
 	pip install -r requirements-dev.txt
@@ -9,7 +10,9 @@ dev-install:
 test: install dev-install
 	pytest -q tests
 
-figs7:
+figs7: install dev-install
+	@ [ -f data/resonance_experiment.csv ] || (echo "Missing: data/resonance_experiment.csv" && exit 1)
+	@ [ -f result/metrics.json ] || (echo "Missing: result/metrics.json" && exit 1)
 	python src/compare_resonance.py data/resonance_experiment.csv result/metrics.json --out docs/plot/fig7_1.png
 	python src/compare_noise.py result/noise_fit.json result/theory_noise.json --out docs/plot/fig7_2.png
 	python src/compare_dd_decay.py data/dd_experiment.csv result/t2.json --out docs/plot/fig7_3.png

--- a/README.md
+++ b/README.md
@@ -318,7 +318,17 @@ python src/generate_error_analysis_flow.py --out docs/plot/fig7_4.png
 python src/fit_theory_experiment_mapping.py result/theory_params_init.json result/metrics.json result/t2.json result/noise_fit.json result/temperature_drift.csv result/heatload.json result/theory_params_validated.json
 ```
 
-## 開発者向けセットアップ：
+# 開発者向けセットアップ：
+
+💡 安全な依存管理のため、以下のように仮想環境の利用を推奨します：
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+make install
+make dev-install
+
+```
 
 ```bash
 # 依存のインストール（本番環境用）
@@ -332,7 +342,14 @@ make test
 
 # Chapter 7 図の再生成
 make figs7
+# 必要なCSVやJSONファイルを事前に配置してください
 ⚠️ Graphviz バインディング（python-graphviz）は requirements.txt に含まれていますが、
 図を出力するには別途 Graphviz 本体（例：apt install graphviz）が必要です。
 未インストール環境では generate_error_analysis_flow.py は自動的にスキップされます。
 ```
+
+⚠️ 注意：
+本プロジェクトでは `src/` ディレクトリをパッケージ化していますが、
+環境によっては `src` という名前の他パッケージと競合する可能性があります。
+競合が発生する場合はプロジェクトルートで `pip install -e .` を実行し、
+`PYTHONPATH=.` を通して動作確認を行ってください。

--- a/src/generate_error_analysis_flow.py
+++ b/src/generate_error_analysis_flow.py
@@ -12,7 +12,7 @@ except Exception:
 
 def main(out_path: str = "docs/plot/fig7_4.png") -> None:
     if Digraph is None:
-        print("Graphviz unavailable")
+        print("Graphviz unavailable (Python binding missing)")
         return
 
     dot = Digraph("error_flow")
@@ -30,7 +30,10 @@ def main(out_path: str = "docs/plot/fig7_4.png") -> None:
     ])
     Path(out_path).parent.mkdir(parents=True, exist_ok=True)
     dot.format = "png"
-    dot.render(out_path, cleanup=True)
+    try:
+        dot.render(out_path, cleanup=True)
+    except Exception as e:
+        print(f"Graphviz render failed: {e}")
 
 
 if __name__ == "__main__":

--- a/tests/test_fit_mapping.py
+++ b/tests/test_fit_mapping.py
@@ -35,6 +35,8 @@ def test_fit_params(tmp_path: Path) -> None:
     assert loaded["fc_GHz"] != 0
     assert loaded["Q_loaded"] > 1
     assert loaded["Gamma_dec"] == t2["Gamma_dec"]
+    assert "noise_A" in loaded and isinstance(loaded["noise_A"], float)
+    assert "noise_B" in loaded and isinstance(loaded["noise_B"], float)
     assert loaded["noise_A"] == noise["noise_model"]["A"]
     assert loaded["noise_B"] == noise["noise_model"]["B"]
     assert isinstance(result, dict)


### PR DESCRIPTION
## Summary
- update Makefile to install project in editable mode and guard `figs7`
- document virtualenv usage and data prerequisites for Chapter 7 figures
- warn about `src` package naming conflicts
- harden Graphviz rendering script
- verify noise parameters types in unit test

## Testing
- `make test` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_683b23570f34832389cc7fdfd386cf5e