### PR TITLE
Finalize setup docs and offline helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 .PHONY: install dev-install test figs7
 
 install:
-	pip install -r requirements.txt
+	# オフラインで使う場合は wheels/ に .whl ファイルを配置し、
+	# pip install --no-index --find-links=wheels -r requirements.txt
+	# を make install に書き換えてください。
+	pip install --no-index --find-links=wheels -r requirements.txt || pip install -r requirements.txt
 	pip install -e .
 
 dev-install:
@@ -13,6 +16,12 @@ test: install dev-install
 figs7: install dev-install
 	@ [ -f data/resonance_experiment.csv ] || (echo "Missing: data/resonance_experiment.csv" && exit 1)
 	@ [ -f result/metrics.json ] || (echo "Missing: result/metrics.json" && exit 1)
+	@ [ -f result/noise_fit.json ] || (echo "Missing: result/noise_fit.json" && exit 1)
+	@ [ -f result/theory_noise.json ] || (echo "Missing: result/theory_noise.json" && exit 1)
+	@ [ -f data/dd_experiment.csv ] || (echo "Missing: data/dd_experiment.csv" && exit 1)
+	@ [ -f result/t2.json ] || (echo "Missing: result/t2.json" && exit 1)
+	@ [ -f result/temperature_drift.csv ] || (echo "Missing: result/temperature_drift.csv" && exit 1)
+	@ [ -f result/heatload.json ] || (echo "Missing: result/heatload.json" && exit 1)
 	python src/compare_resonance.py data/resonance_experiment.csv result/metrics.json --out docs/plot/fig7_1.png
 	python src/compare_noise.py result/noise_fit.json result/theory_noise.json --out docs/plot/fig7_2.png
 	python src/compare_dd_decay.py data/dd_experiment.csv result/t2.json --out docs/plot/fig7_3.png

--- a/README.md
+++ b/README.md
@@ -318,13 +318,33 @@ python src/generate_error_analysis_flow.py --out docs/plot/fig7_4.png
 python src/fit_theory_experiment_mapping.py result/theory_params_init.json result/metrics.json result/t2.json result/noise_fit.json result/temperature_drift.csv result/heatload.json result/theory_params_validated.json
 ```
 
-# 開発者向けセットアップ：
+## 🗂 必要な実験データ（Chapter 7 用）
 
-💡 安全な依存管理のため、以下のように仮想環境の利用を推奨します：
+以下のファイルが必要です：
+
+- `data/resonance_experiment.csv`：共鳴スペクトルの生データ（freq, I, Q）
+- `result/metrics.json`：extract_quantum_metrics.py により生成
+- `result/noise_fit.json`：compute_noise_spectrum.py により生成
+- `result/theory_noise.json`：simulate_noise_spectrum.py により生成
+- `data/dd_experiment.csv`：DD 実験による N, coherence
+- `result/t2.json`：extract_t2_from_dd.py により生成
+- `result/temperature_drift.csv`：温度 vs 時刻のドリフトログ
+- `result/heatload.json`：sim_cooling_heatload.py により生成
+
+## 🔧 開発者向けセットアップ
+
+💡 推奨：Python 3.8 以上
 
 ```bash
+# 仮想環境の作成（Unix/macOS）
 python -m venv .venv
 source .venv/bin/activate
+
+# 仮想環境の作成（Windows）
+python -m venv .venv
+\.venv\Scripts\activate
+
+# 必要な依存のインストール
 make install
 make dev-install
 
@@ -349,7 +369,11 @@ make figs7
 ```
 
 ⚠️ 注意：
-本プロジェクトでは `src/` ディレクトリをパッケージ化していますが、
-環境によっては `src` という名前の他パッケージと競合する可能性があります。
-競合が発生する場合はプロジェクトルートで `pip install -e .` を実行し、
-`PYTHONPATH=.` を通して動作確認を行ってください。
+`src/` および `tools/` は Python パッケージとして認識されますが、
+環境によっては `src` や `tools` という名前の別パッケージと競合する可能性があります。
+
+- 競合エラーが発生する場合：
+  - `pip install -e .` を先に実行してください。
+  - もしくは `PYTHONPATH=.` を通して実行してください。
+
+将来的に避けたい場合は、独自名前空間（例：`ifg/`）への移行を検討してください。

--- a/src/generate_error_analysis_flow.py
+++ b/src/generate_error_analysis_flow.py
@@ -12,7 +12,7 @@ except Exception:
 
 def main(out_path: str = "docs/plot/fig7_4.png") -> None:
     if Digraph is None:
-        print("Graphviz unavailable (Python binding missing)")
+        print("\u26A0\ufe0f  Graphviz unavailable (Python binding missing)")
         return
 
     dot = Digraph("error_flow")
@@ -33,7 +33,7 @@ def main(out_path: str = "docs/plot/fig7_4.png") -> None:
     try:
         dot.render(out_path, cleanup=True)
     except Exception as e:
-        print(f"Graphviz render failed: {e}")
+        print(f"\u26A0\ufe0f  Graphviz render failed: {e}")
 
 
 if __name__ == "__main__":

--- a/tests/test_fit_mapping.py
+++ b/tests/test_fit_mapping.py
@@ -34,6 +34,7 @@ def test_fit_params(tmp_path: Path) -> None:
 
     assert loaded["fc_GHz"] != 0
     assert loaded["Q_loaded"] > 1
+    assert "Gamma_dec" in loaded and isinstance(loaded["Gamma_dec"], (int, float))
     assert loaded["Gamma_dec"] == t2["Gamma_dec"]
     assert "noise_A" in loaded and isinstance(loaded["noise_A"], float)
     assert "noise_B" in loaded and isinstance(loaded["noise_B"], float)


### PR DESCRIPTION
## Summary
- improve `install` with offline fallback and add fig7 checks
- document virtualenv steps and required experiment data
- warn about potential package name conflicts
- handle missing Graphviz more gracefully
- harden mapping test

## Testing
- `make install` *(fails: Could not find a version that satisfies the requirement numpy)*
- `make dev-install` *(fails: Could not find a version that satisfies the requirement flake8)*
- `make test` *(fails: Could not find a version that satisfies the requirement numpy)*
- `make figs7` *(fails: Could not find a version that satisfies the requirement numpy)*
- `python src/generate_error_analysis_flow.py --out test.png`

------
https://chatgpt.com/codex/tasks/task_e_683b258ba00083239688c0bfe2a42497